### PR TITLE
Convert string to snake case not working as expected

### DIFF
--- a/api/src/Utils/StringManipulator.php
+++ b/api/src/Utils/StringManipulator.php
@@ -6,7 +6,7 @@ class StringManipulator
 {
     public static function convertToSnakeCase(string $string): string
     {
-        $pattern = '!([A-Z][A-Z0-9]*(?=$|[A-Z][a-z0-9])|[A-Za-z][a-z0-9]+)!';
+        $pattern = '!\b[a-zA-Z0-9]+(?:[a-zA-Z0-9]+)*!';
         preg_match_all($pattern, $string, $matches);
         $ret = $matches[0];
         foreach ($ret as &$match) {


### PR DESCRIPTION
Pattern to convert a string to snake case was not working with more than one uppercase word

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)